### PR TITLE
Update contact information in ietf-template.yang

### DIFF
--- a/templates/ietf-template.yang
+++ b/templates/ietf-template.yang
@@ -20,8 +20,8 @@ module ietf-template {
   // update this contact statement with your info
 
   contact
-    "WG Web:   <http://datatracker.ietf.org/wg/your-wg-name/>
-     WG List:  <mailto:your-wg-name@ietf.org>
+    "WG Web:   http://datatracker.ietf.org/wg/your-wg-name
+     WG List:  YOUR-WG-NAME <mailto:your-wg-name@ietf.org>
 
      Editor:   your-name
                <mailto:your-email@example.com>";


### PR DESCRIPTION
1) it is unnecessary/confusing to have angle-brackets around the "WG Web" URL  (what do they mean?)

2) the "WG List" line having the name of the WG (in caps) outside the <mailto> element is useful.